### PR TITLE
Demo: image scaling provides incorrect values

### DIFF
--- a/test/browser_test.html
+++ b/test/browser_test.html
@@ -215,7 +215,12 @@
 			log.windowSize = pair[2];
 			log.luminance = pair[3];
 			var start = new Date().getTime();
-			var res = ImageSSIM.compare(images[0], images[1], pair[2], 0.01, 0.03, pair[3])
+			var res;
+			try {
+				res = ImageSSIM.compare(images[0], images[1], pair[2], 0.01, 0.03, pair[3])
+			} catch (e) {
+				alert(e);
+			}
 			log.ssim = Math.round(res.ssim * 1000) / 1000;
 			// log.mcs = Math.round(res.mcs * 1000) / 1000;
 			log.ellapsed = new Date().getTime() - start + 'ms';

--- a/test/browser_test.html
+++ b/test/browser_test.html
@@ -69,6 +69,7 @@
 			display: block;
 			border: 1px solid rgba(0, 0, 0, .12);
 			margin-bottom: 20px;
+			width: 100%;
 		}
 
 		.clear {
@@ -173,10 +174,10 @@
 		var img = new Image();
 		img.onload = function () {
 			var canvas = document.createElement('canvas');
-			canvas.width = width;
-			canvas.height = height;
+			canvas.width = img.width;
+			canvas.height = img.height;
 			var ctx = canvas.getContext('2d');
-			ctx.drawImage(img, 0, 0, width, canvas.height);
+			ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
 			var id = ctx.getImageData(0, 0, canvas.width, canvas.height);
 			done({width: canvas.width, height: canvas.height, data: id.data, channels: 4, canvas: canvas}, index);
 		};


### PR DESCRIPTION
Since the demo page forces images into a square, the SSIM values end up being way different than if the images were evaluated on their original aspect ratio and size.

This PR...

1. Uses canvas of the image's size and compares that. 
1. It adjusts CSS so the new canvas fits nicely in the block.
1. And as two images with different sizes can no longer be tested against eachother, we alert the user to that error. :)


cc @patrickhulce

Before and after:
![image](https://cloud.githubusercontent.com/assets/39191/26022047/f279837e-374e-11e7-8274-b1cb367c33a6.png)
